### PR TITLE
Fixing method call bug in canBeReviewedBy()

### DIFF
--- a/code/extensions/SiteTreeContentReview.php
+++ b/code/extensions/SiteTreeContentReview.php
@@ -453,6 +453,10 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
         }
 
         $options = $this->getOptions();
+        
+        if (!$options) {
+            return false;
+        }
 
         if ($options->OwnerGroups()->count() == 0 && $options->OwnerUsers()->count() == 0) {
             return false;


### PR DESCRIPTION
If getOptions returns false, then canBeReviewedBy() throws "Call to a member function OwnerGroups() on boolean".
This will return false in the case that $options is false.